### PR TITLE
Adding push logs to stdout for docker logging

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -19,4 +19,6 @@ COPY entry.sh /entry.sh
 RUN chmod 755 /entry.sh
 RUN /usr/bin/crontab /crontab.txt
 
+RUN ln -sf /dev/stdout /var/log/script.log
+
 CMD ["/entry.sh"]


### PR DESCRIPTION
### What

Added command to local dockerfile so when `docker logs <container-id>` is queried logs are output.

### How to review

Run the dataset catalogue stack with this branch of dis-bundle-scheduler and logs for the bundle scheduler should be output when the `docker logs <container-id>` command is run.

### Who can review

Anyone.
