### PR TITLE
Improve accuracy and tidy up

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 version: "2"
 run:
   concurrency: 4
+  timeout: 5m
 linters:
   default: none
   enable:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ audit:
 
 .PHONY: lint
 lint:
-	golangci-lint run --timeout=5m ./...
+	golangci-lint run
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ audit:
 
 .PHONY: lint
 lint:
-	golangci-lint run ./...
+	golangci-lint run --timeout=5m ./...
 
 .PHONY: build
 build:

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,7 @@ import (
 	"github.com/kelseyhightower/envconfig"
 )
 
-// Config represents service configuration for dis-data-bundle-scheduler
+// Config represents service configuration for dis-bundle-scheduler
 type Configuration struct {
 	ServiceToken  string `envconfig:"BUNDLES_API_SERVICE_TOKEN"  json:"-"`
 	BundlesAPIUrl string `envconfig:"BUNDLES_API_URL"`

--- a/dis-bundle-scheduler.nomad
+++ b/dis-bundle-scheduler.nomad
@@ -6,7 +6,7 @@ job "dis-bundle-scheduler" {
   periodic {
     cron             = "* * * * *"
     time_zone        = "UTC"
-    prohibit_overlap = true
+    prohibit_overlap = false
   }
 
   group "publishing" {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ONSdigital/dis-bundle-scheduler
 
-go 1.24.4
+go 1.24
 
 require (
 	github.com/ONSdigital/dis-bundle-api v1.7.0
@@ -9,6 +9,8 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/smartystreets/goconvey v1.8.1
 )
+
+require github.com/stretchr/testify v1.11.1 // indirect
 
 require (
 	github.com/ONSdigital/dp-api-clients-go/v2 v2.269.0 // indirect
@@ -20,7 +22,6 @@ require (
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
-	github.com/golang/mock v1.6.0
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f // indirect
 	github.com/jtolds/gls v4.20.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/smarty/assertions v1.16.0 h1:EvHNkdRA4QHMrn75NZSoUQ/mAUXAYWfatfB01yTC
 github.com/smarty/assertions v1.16.0/go.mod h1:duaaFdCS0K9dnoM50iyek/eYINOZ64gbh1Xlf6LG7AI=
 github.com/smartystreets/goconvey v1.8.1 h1:qGjIddxOk4grTu9JPOU31tVfq3cNdBlNa5sSznIX1xY=
 github.com/smartystreets/goconvey v1.8.1/go.mod h1:+/u4qLyY6x1jReYOp7GOM2FSt8aP9CzCZL03bI28W60=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.mongodb.org/mongo-driver v1.17.4 h1:jUorfmVzljjr0FLzYQsGP8cgN/qzzxlY9Vh0C9KFXVw=
 go.mongodb.org/mongo-driver v1.17.4/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/publisher/publisher.go
+++ b/publisher/publisher.go
@@ -22,7 +22,6 @@ type PublishBundleResult struct {
 }
 
 type PublishResult struct {
-	// need to make an object for here
 	Results []PublishBundleResult
 	Success bool
 }
@@ -61,8 +60,8 @@ func (p *Publisher) Run(ctx context.Context) (*PublishResult, error) {
 	// The time to check for scheduled publication, this is rounded to the nearest minute as publication on the minute
 	// is what is provided to users to enter.  Validation is carried out below to ensure publications are not made early
 	now := time.Now().UTC()
-	// get difference between now and next minute
-	nextMinute := now.Add(time.Minute * 1)
+	// get difference between now and next minute - to the whole minute to improve accuracy
+	nextMinute := now.Truncate(time.Minute).Add(time.Minute)
 	logData := log.Data{"publish_date": nextMinute}
 
 	cfg, err := config.Get()
@@ -91,8 +90,8 @@ func (p *Publisher) Run(ctx context.Context) (*PublishResult, error) {
 
 	var publicationList PublishResult
 
-	// Get the time difference between the minute submitted in the query and the current time
-	publishCheck := nextMinute.Sub(time.Now().UTC())
+	// Get the time difference between the minute submitted in the query and the current time as specified above
+	publishCheck := nextMinute.Sub(now)
 
 	// Check to ensure bundles are not published early - sleeps the process for the amount of time between current time
 	// above and publication time

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -97,9 +97,7 @@ func TestRunScheduler(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		body, err := json.Marshal(testBundleForPublish)
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		bundleAPIMock := &bundleMocks.ClienterMock{
 			GetBundlesFunc: func(ctx context.Context, headers sdk.Headers, scheduledAt *time.Time, queryParams *sdk.QueryParams) (result *sdk.BundlesList, err errors.Error) {
@@ -113,9 +111,7 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
@@ -129,9 +125,7 @@ func TestRunScheduler(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		body, err := json.Marshal(testBundleIncorrectState)
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		bundleAPIMock := &bundleMocks.ClienterMock{
 			GetBundlesFunc: func(ctx context.Context, headers sdk.Headers, scheduledAt *time.Time, queryParams *sdk.QueryParams) (result *sdk.BundlesList, err errors.Error) {
@@ -145,9 +139,7 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
@@ -165,9 +157,7 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
@@ -188,9 +178,7 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
@@ -204,9 +192,7 @@ func TestRunScheduler(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		body, err := json.Marshal(testBundleForPublish)
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		bundleAPIMock := &bundleMocks.ClienterMock{
 			GetBundlesFunc: func(ctx context.Context, headers sdk.Headers, scheduledAt *time.Time, queryParams *sdk.QueryParams) (result *sdk.BundlesList, err errors.Error) {
@@ -220,9 +206,7 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		if err != nil {
-			So(err, ShouldNotBeNil)
-		}
+		So(err, ShouldBeNil)
 
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())

--- a/publisher/publisher_test.go
+++ b/publisher/publisher_test.go
@@ -98,7 +98,7 @@ func TestRunScheduler(t *testing.T) {
 
 		body, err := json.Marshal(testBundleForPublish)
 		if err != nil {
-			fmt.Println(err)
+			So(err, ShouldNotBeNil)
 		}
 
 		bundleAPIMock := &bundleMocks.ClienterMock{
@@ -113,7 +113,10 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		fmt.Println(err)
+		if err != nil {
+			So(err, ShouldNotBeNil)
+		}
+
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
 			So(err, ShouldBeNil)
@@ -127,7 +130,7 @@ func TestRunScheduler(t *testing.T) {
 
 		body, err := json.Marshal(testBundleIncorrectState)
 		if err != nil {
-			fmt.Println(err)
+			So(err, ShouldNotBeNil)
 		}
 
 		bundleAPIMock := &bundleMocks.ClienterMock{
@@ -142,7 +145,10 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		fmt.Println(err)
+		if err != nil {
+			So(err, ShouldNotBeNil)
+		}
+
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
 			So(err, ShouldBeNil)
@@ -159,7 +165,10 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		fmt.Println(err)
+		if err != nil {
+			So(err, ShouldNotBeNil)
+		}
+
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
 			So(err, ShouldNotBeNil)
@@ -179,7 +188,10 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		fmt.Println(err)
+		if err != nil {
+			So(err, ShouldNotBeNil)
+		}
+
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
 			So(err, ShouldBeNil)
@@ -193,8 +205,9 @@ func TestRunScheduler(t *testing.T) {
 
 		body, err := json.Marshal(testBundleForPublish)
 		if err != nil {
-			fmt.Println(err)
+			So(err, ShouldNotBeNil)
 		}
+
 		bundleAPIMock := &bundleMocks.ClienterMock{
 			GetBundlesFunc: func(ctx context.Context, headers sdk.Headers, scheduledAt *time.Time, queryParams *sdk.QueryParams) (result *sdk.BundlesList, err errors.Error) {
 				return &testBundles, err
@@ -207,7 +220,10 @@ func TestRunScheduler(t *testing.T) {
 			},
 		}
 		pubPublish, err := publisher.CreatePublisher(cfg, publisher.ClientList{bundleAPIMock})
-		fmt.Println(err)
+		if err != nil {
+			So(err, ShouldNotBeNil)
+		}
+
 		if pubPublish != nil {
 			publishResult, err := pubPublish.Run(context.Background())
 			So(err, ShouldBeNil)


### PR DESCRIPTION
### What

Amended the nomad plan to allow more than one task to start up which will handle overlaps in publication time while an instance is waiting for the specific time to publish.
Amended time unit to improve accuracy in judging how much time to wait before starting the bundle publication process - local testing showed slight improvements in publishing multiple bundles.
Minor tidy ups.

### How to review

Ensure the tests pass and the changes make sense.  For a more detailed review, run the dataset catalogue stack and schedule a bundle for publication (needs to be in the APPROVED state).  Ensure the bundle is not published early.

### Who can review

Anyone.
